### PR TITLE
fix: some gremlins on the apps resolve

### DIFF
--- a/pkg/cmd/apps/resolve/test_data/expected-jx-apps.yml
+++ b/pkg/cmd/apps/resolve/test_data/expected-jx-apps.yml
@@ -29,4 +29,4 @@ repositories:
 - name: external-secrets
   url: https://godaddy.github.io/kubernetes-external-secrets
 values:
-- jx-requirements.values.yaml  
+- jx-values.yaml

--- a/pkg/jxtmpl/reqvalues/requirements_values.go
+++ b/pkg/jxtmpl/reqvalues/requirements_values.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	// RequirementsValuesFileName is the name of the requirements configuration file
-	RequirementsValuesFileName = "jx-requirements.values.yaml"
+	// RequirementsValuesFileName is the name of the helm values.yaml configuration file for common Jenkins X values
+	// such as cluster information, environments and ingress
+	RequirementsValuesFileName = "jx-values.yaml"
 )
 
 // RequirementsValues contains the logical installation requirements in the `jx-requirements.yml` file as helm values


### PR DESCRIPTION
due to some bugs around version stream dir handling

also moved to the nicer named file `jx-values.yaml` which is the file we can pass into helm charts