### PR TITLE
fix: avoid overwriting the gitServer

### DIFF
--- a/jenkins-x.yml
+++ b/jenkins-x.yml
@@ -20,6 +20,15 @@ pipelineConfig:
         - agent:
             image: gcr.io/jenkinsxio/builder-go
           name: chart
+          options:
+            containerOptions:
+              resources:
+                limits:
+                  cpu: 3
+                  memory: 3072Mi
+                requests:
+                  cpu: 2
+                  memory: 2048Mi
           steps:
           - name: release-binary
             command: make release

--- a/pkg/cmd/requirement/merge/merge.go
+++ b/pkg/cmd/requirement/merge/merge.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jenkins-x/jx-helpers/pkg/files"
 	"github.com/jenkins-x/jx-helpers/pkg/kube"
 	"github.com/jenkins-x/jx-helpers/pkg/termcolor"
+	"github.com/jenkins-x/jx-helpers/pkg/yamls"
 	"github.com/jenkins-x/jx-logging/pkg/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -100,12 +101,11 @@ func (o *Options) Run() error {
 		o.requirementsFileName = filepath.Join(o.Dir, config.RequirementsConfigFileName)
 	}
 
-	requirementChanges, err := config.LoadRequirementsConfigFile(o.File, false)
+	// lets not se the usual loading as we dno't want any default values populated
+	requirementChanges := &config.RequirementsConfig{}
+	err = yamls.LoadFile(o.File, requirementChanges)
 	if err != nil {
-		return errors.Wrapf(err, "failed to load changes from file: %s", o.File)
-	}
-	if requirementChanges == nil {
-		return errors.Errorf("no requirements config found for file: %s", o.File)
+		return errors.Wrapf(err, "failed to unmarshal YAML changes from file: %s", o.File)
 	}
 
 	exists := false

--- a/pkg/cmd/requirement/merge/test_data/expected.yml
+++ b/pkg/cmd/requirement/merge/test_data/expected.yml
@@ -12,7 +12,7 @@ cluster:
   environmentGitOwner: todo
   gitKind: github
   gitName: github
-  gitServer: https://github.com
+  gitServer: https://acme.com
   namespace: jx
   project: jenkins-x-labs-bdd
   provider: gke

--- a/pkg/cmd/requirement/merge/test_data/jx-requirements.yml
+++ b/pkg/cmd/requirement/merge/test_data/jx-requirements.yml
@@ -14,7 +14,7 @@ cluster:
   environmentGitOwner: "todo"
   gitKind: github
   gitName: github
-  gitServer: https://github.com
+  gitServer: https://acme.com
   namespace: jx
   project:  ""
   provider: gke


### PR DESCRIPTION
when we load the merge changes from Terraform we should not populate
default values like gitServer: "https://github.com" otherwise the merge
logic thinks Terraform is configuring the git server and we end up losing
the users gitServer value

so lets load the YAML file without applying any default values