### PR TITLE
fix: support separate ingress domain / subdomain per namespace

### DIFF
--- a/pkg/jxtmpl/reqvalues/requirements_values.go
+++ b/pkg/jxtmpl/reqvalues/requirements_values.go
@@ -29,6 +29,6 @@ func SaveRequirementsValuesFile(c *config.RequirementsConfig, fileName string) e
 	if err != nil {
 		return errors.Wrapf(err, "failed to save file %s", fileName)
 	}
-	log.Logger().Infof("generated helm YAML file from jx requirements at %s", termcolor.ColorInfo(fileName))
+	log.Logger().Debugf("generated helm YAML file from jx requirements at %s", termcolor.ColorInfo(fileName))
 	return nil
 }


### PR DESCRIPTION
so that production/staging charts have separate ingress host names if the same app is deployed to both namespaces and we are using a single cluster

we use a separate jx-values-$namespace.yaml file using the ingress from the `jx-requirements.yml` or a custom namespace specific subdomain

fixes #237