### PR TITLE
fix: lets move the repo/merge/context options out of presubmits

### DIFF
--- a/pkg/cmd/scheduler/test_data/versionStream/schedulers/default.yaml
+++ b/pkg/cmd/scheduler/test_data/versionStream/schedulers/default.yaml
@@ -69,40 +69,40 @@ spec:
             contexts:
               entries:
                 - pr-build
-        queries:
-          - excludedBranches: { }
-            included_branches: { }
-            labels:
-              entries:
-                - approved
-            milestone: ""
-            missingLabels:
-              entries:
-                - do-not-merge
-                - do-not-merge/hold
-                - do-not-merge/work-in-progress
-                - needs-ok-to-test
-                - needs-rebase
-            review_approved_required: false
-          - excludedBranches: { }
-            included_branches: { }
-            labels:
-              entries:
-                - updatebot
-            milestone: ""
-            missingLabels:
-              entries:
-                - do-not-merge
-                - do-not-merge/hold
-                - do-not-merge/work-in-progress
-                - needs-ok-to-test
-                - needs-rebase
-            review_approved_required: false
         report: true
         rerun_command: /test this
         run_if_changed: ""
         skip_branches: [ ]
         trigger: (?m)^/test( all| this),?(\s+|$)
+  queries:
+    - excludedBranches: { }
+      included_branches: { }
+      labels:
+        entries:
+          - approved
+      milestone: ""
+      missingLabels:
+        entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      review_approved_required: false
+    - excludedBranches: { }
+      included_branches: { }
+      labels:
+        entries:
+          - updatebot
+      milestone: ""
+      missingLabels:
+        entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      review_approved_required: false
   schedulerAgent:
     agent: tekton
   trigger:

--- a/pkg/cmd/scheduler/test_data/versionStream/schedulers/environment.yaml
+++ b/pkg/cmd/scheduler/test_data/versionStream/schedulers/environment.yaml
@@ -70,40 +70,40 @@ spec:
             contexts:
               entries:
                 - promotion-build
-        queries:
-          - excludedBranches: { }
-            included_branches: { }
-            labels:
-              entries:
-                - approved
-            milestone: ""
-            missingLabels:
-              entries:
-                - do-not-merge
-                - do-not-merge/hold
-                - do-not-merge/work-in-progress
-                - needs-ok-to-test
-                - needs-rebase
-            review_approved_required: false
-          - excludedBranches: { }
-            included_branches: { }
-            labels:
-              entries:
-                - updatebot
-            milestone: ""
-            missingLabels:
-              entries:
-                - do-not-merge
-                - do-not-merge/hold
-                - do-not-merge/work-in-progress
-                - needs-ok-to-test
-                - needs-rebase
-            review_approved_required: false
         report: true
         rerun_command: /test this
         run_if_changed: ""
         skip_branches: [ ]
         trigger: (?m)^/test( all| this),?(\s+|$)
+  queries:
+    - excludedBranches: { }
+      included_branches: { }
+      labels:
+        entries:
+          - approved
+      milestone: ""
+      missingLabels:
+        entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      review_approved_required: false
+    - excludedBranches: { }
+      included_branches: { }
+      labels:
+        entries:
+          - updatebot
+      milestone: ""
+      missingLabels:
+        entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      review_approved_required: false
   schedulerAgent:
     agent: tekton
   trigger:

--- a/pkg/cmd/scheduler/test_data/versionStream/schedulers/in-repo.yaml
+++ b/pkg/cmd/scheduler/test_data/versionStream/schedulers/in-repo.yaml
@@ -39,6 +39,35 @@ spec:
       - pony
   policy:
     protect_tested: true
+  queries:
+    - excludedBranches: { }
+      included_branches: { }
+      labels:
+        entries:
+          - approved
+      milestone: ""
+      missingLabels:
+        entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      review_approved_required: false
+    - excludedBranches: { }
+      included_branches: { }
+      labels:
+        entries:
+          - updatebot
+      milestone: ""
+      missingLabels:
+        entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      review_approved_required: false
   schedulerAgent:
     agent: tekton
   trigger:

--- a/pkg/cmd/scheduler/test_data/versionStream/schedulers/jx-meta-pipeline.yaml
+++ b/pkg/cmd/scheduler/test_data/versionStream/schedulers/jx-meta-pipeline.yaml
@@ -64,39 +64,41 @@ spec:
         pipeline_run_spec:
           pipelineRef:
             name: jx-meta-pipeline
-        queries:
-          - excludedBranches: { }
-            included_branches: { }
-            labels:
-              entries:
-                - approved
-            milestone: ""
-            missingLabels:
-              entries:
-                - do-not-merge
-                - do-not-merge/hold
-                - do-not-merge/work-in-progress
-                - needs-ok-to-test
-                - needs-rebase
-            review_approved_required: false
-          - excludedBranches: { }
-            included_branches: { }
-            labels:
-              entries:
-                - updatebot
-            milestone: ""
-            missingLabels:
-              entries:
-                - do-not-merge
-                - do-not-merge/hold
-                - do-not-merge/work-in-progress
-                - needs-ok-to-test
-                - needs-rebase
-            review_approved_required: false
         report: true
         rerun_command: /test this
         run_if_changed: ""
         trigger: (?m)^/test( all| this),?(\s+|$)
+
+  queries:
+    - excludedBranches: { }
+      included_branches: { }
+      labels:
+        entries:
+          - approved
+      milestone: ""
+      missingLabels:
+        entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      review_approved_required: false
+    - excludedBranches: { }
+      included_branches: { }
+      labels:
+        entries:
+          - updatebot
+      milestone: ""
+      missingLabels:
+        entries:
+          - do-not-merge
+          - do-not-merge/hold
+          - do-not-merge/work-in-progress
+          - needs-ok-to-test
+          - needs-rebase
+      review_approved_required: false
+
   schedulerAgent:
     agent: tekton
   trigger:

--- a/pkg/pipelinescheduler/builder.go
+++ b/pkg/pipelinescheduler/builder.go
@@ -398,12 +398,12 @@ func applyToPostSubmits(parentPostsubmits *schedulerapi.Postsubmits, childPostsu
 
 func applyToPreSubmits(parentPresubmits *schedulerapi.Presubmits, childPresubmits *schedulerapi.Presubmits) error {
 	if childPresubmits.Items == nil {
-		childPresubmits.Items = make([]*schedulerapi.Presubmit, 0)
+		childPresubmits.Items = make([]*job.Presubmit, 0)
 	}
 	// Work through each of the presubmits in the parent. If we can find a name based match in child,
 	// we apply it to the child, otherwise we append it
 	for _, parent := range parentPresubmits.Items {
-		var found []*schedulerapi.Presubmit
+		var found []*job.Presubmit
 		for _, child := range childPresubmits.Items {
 			if child.Name == parent.Name {
 				found = append(found, child)

--- a/pkg/pipelinescheduler/builder.go
+++ b/pkg/pipelinescheduler/builder.go
@@ -42,6 +42,27 @@ func Build(schedulers []*schedulerapi.SchedulerSpec) (*schedulerapi.SchedulerSpe
 					return nil, errors.WithStack(err)
 				}
 			}
+
+			// combine the queries
+			if answer.Queries == nil {
+				answer.Queries = parent.Queries
+			} else {
+				applyToQueries(parent.Queries, answer.Queries)
+			}
+			if answer.MergeMethod == nil {
+				answer.MergeMethod = parent.MergeMethod
+			}
+			if answer.ProtectionPolicy == nil {
+				answer.ProtectionPolicy = parent.ProtectionPolicy
+			} else if parent.ProtectionPolicy != nil {
+				applyToProtectionPolicies(parent.ProtectionPolicy, answer.ProtectionPolicy)
+			}
+			if answer.ContextOptions == nil {
+				answer.ContextOptions = parent.ContextOptions
+			} else if parent.ContextOptions != nil {
+				applyToRepoContextPolicy(parent.ContextOptions, answer.ContextOptions)
+			}
+
 			//TODO: This should probably be an array of triggers, because the plugins yaml is expecting an array
 			if answer.Trigger == nil {
 				answer.Trigger = parent.Trigger

--- a/pkg/pipelinescheduler/config_builder.go
+++ b/pkg/pipelinescheduler/config_builder.go
@@ -337,7 +337,7 @@ func buildJobConfig(jobConfig *config.JobConfig, prowConfig *config.ProwConfig,
 		}
 	}
 	if scheduler.Presubmits != nil && scheduler.Presubmits.Items != nil {
-		err := buildPresubmits(jobConfig, prowConfig, scheduler.Presubmits.Items, scheduler.Queries, org, repo)
+		err := buildPresubmits(jobConfig, scheduler.Presubmits.Items, org, repo)
 		if err != nil {
 			return errors.Wrapf(err, "building Presubmits from %v", scheduler)
 		}
@@ -428,7 +428,7 @@ func buildKeeperConfig(prowConfig *config.ProwConfig, queries []*schedulerapi.Qu
 	return nil
 }
 
-func buildPresubmits(jobConfig *config.JobConfig, prowConfig *config.ProwConfig, items []*schedulerapi.Presubmit, queries []*schedulerapi.Query, orgName string, repoName string) error {
+func buildPresubmits(jobConfig *config.JobConfig, items []*job.Presubmit, orgName string, repoName string) error {
 	if jobConfig.Presubmits == nil {
 		jobConfig.Presubmits = make(map[string][]job.Presubmit)
 	}
@@ -438,7 +438,7 @@ func buildPresubmits(jobConfig *config.JobConfig, prowConfig *config.ProwConfig,
 		if _, ok := jobConfig.Presubmits[orgSlashRepo]; !ok {
 			jobConfig.Presubmits[orgSlashRepo] = make([]job.Presubmit, 0)
 		}
-		jobConfig.Presubmits[orgSlashRepo] = append(jobConfig.Presubmits[orgSlashRepo], r.Presubmit)
+		jobConfig.Presubmits[orgSlashRepo] = append(jobConfig.Presubmits[orgSlashRepo], *r)
 	}
 	return nil
 }

--- a/pkg/pipelinescheduler/scheduler_builder.go
+++ b/pkg/pipelinescheduler/scheduler_builder.go
@@ -531,9 +531,7 @@ func buildSchedulerPresubmits(repo string, prowConfig *config.Config) *scheduler
 	presubmits := prowConfig.Presubmits[repo]
 	for presubmitIndex := range presubmits {
 		copy := presubmits[presubmitIndex]
-		schedulerPresubmits.Items = append(schedulerPresubmits.Items, &schedulerapi.Presubmit{
-			Presubmit: copy,
-		})
+		schedulerPresubmits.Items = append(schedulerPresubmits.Items, &copy)
 	}
 	return schedulerPresubmits
 }

--- a/pkg/pipelinescheduler/test_data/merger_with_mergemethod/parent.yaml
+++ b/pkg/pipelinescheduler/test_data/merger_with_mergemethod/parent.yaml
@@ -46,23 +46,25 @@ presubmits:
       context: integration
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
-      queries:
-        - labels:
-            entries:
-              - approved
-          missingLabels:
-            entries:
-              - do-not-merge
-              - do-not-merge/hold
-              - do-not-merge/work-in-progress
-              - needs-ok-to-test
-              - needs-rebase
-      policy:
-        protect: true
-        required_status_checks:
-          contexts:
-            entries:
-              - integration
+      
+queries:
+  - labels:
+      entries:
+        - approved
+    missingLabels:
+      entries:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - needs-ok-to-test
+        - needs-rebase
+
+protection_policy:
+  protect: true
+  required_status_checks:
+    contexts:
+      entries:
+        - integration
 plugins:
   entries:
     - config-updater

--- a/pkg/pipelinescheduler/test_data/merger_with_parent/parent.yaml
+++ b/pkg/pipelinescheduler/test_data/merger_with_parent/parent.yaml
@@ -45,23 +45,26 @@ presubmits:
       context: integration
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
-      queries:
-        - labels:
-            entries:
-              - approved
-          missingLabels:
-            entries:
-              - do-not-merge
-              - do-not-merge/hold
-              - do-not-merge/work-in-progress
-              - needs-ok-to-test
-              - needs-rebase
-      policy:
-        protect: true
-        required_status_checks:
-          contexts:
-            entries:
-              - integration
+
+queries:
+  - labels:
+      entries:
+        - approved
+    missingLabels:
+      entries:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - needs-ok-to-test
+        - needs-rebase
+
+protection_policy:
+  protect: true
+  required_status_checks:
+    contexts:
+      entries:
+        - integration
+
 plugins:
   entries:
     - config-updater

--- a/pkg/pipelinescheduler/test_data/multiple_contexts/repo.yaml
+++ b/pkg/pipelinescheduler/test_data/multiple_contexts/repo.yaml
@@ -17,63 +17,36 @@ presubmits:
       name: integration
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
-      queries:
-        - labels:
-            entries:
-              - approved
-          missingLabels:
-            entries:
-              - do-not-merge
-              - do-not-merge/hold
-              - do-not-merge/work-in-progress
-              - needs-ok-to-test
-              - needs-rebase
-      policy:
-        protect: true
-        required_status_checks:
-          contexts:
-            entries:
-              - integration
     - agent: tekton
       always_run: true
       context: context2
       name: context2
       rerun_command: /test context2
       trigger: (?m)^/test( all| context2),?(\s+|$)
-      queries:
-        - labels:
-            entries:
-              - approved
-          missingLabels:
-            entries:
-              - do-not-merge
-              - do-not-merge/hold
-              - do-not-merge/work-in-progress
-              - needs-ok-to-test
-              - needs-rebase
-      policy:
-        protect: true
-        required_status_checks:
-          contexts:
-            entries:
-              - context2
     - agent: tekton
       always_run: false
       context: context3
       name: context3
       rerun_command: /test context3
       trigger: (?m)^/test( all| context3),?(\s+|$)
-      queries:
-        - labels:
-            entries:
-              - approved
-          missingLabels:
-            entries:
-              - do-not-merge
-              - do-not-merge/hold
-              - do-not-merge/work-in-progress
-              - needs-ok-to-test
-              - needs-rebase
+queries:
+  - labels:
+      entries:
+        - approved
+    missingLabels:
+      entries:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - needs-ok-to-test
+        - needs-rebase
+protection_policy:
+  protect: true
+  required_status_checks:
+    contexts:
+      entries:
+        - integration
+        - context2
 merger:
   policy:
     from-branch-protection: true

--- a/pkg/pipelinescheduler/test_data/no_postsubmits_with_parent/parent.yaml
+++ b/pkg/pipelinescheduler/test_data/no_postsubmits_with_parent/parent.yaml
@@ -32,23 +32,23 @@ presubmits:
       context: integration
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
-      queries:
-        - labels:
-            entries:
-              - approved
-          missingLabels:
-            entries:
-              - do-not-merge
-              - do-not-merge/hold
-              - do-not-merge/work-in-progress
-              - needs-ok-to-test
-              - needs-rebase
-      policy:
-        protect: true
-        required_status_checks:
-          contexts:
-            entries:
-              - integration
+queries:
+  - labels:
+      entries:
+        - approved
+    missingLabels:
+      entries:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - needs-ok-to-test
+        - needs-rebase
+protection_policy:
+  protect: true
+  required_status_checks:
+    contexts:
+      entries:
+        - integration
 plugins:
   entries:
     - config-updater

--- a/pkg/pipelinescheduler/test_data/only_with_parent/parent.yaml
+++ b/pkg/pipelinescheduler/test_data/only_with_parent/parent.yaml
@@ -23,23 +23,23 @@ presubmits:
       context: integration
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
-      queries:
-        - labels:
-            entries:
-              - approved
-          missingLabels:
-            entries:
-              - do-not-merge
-              - do-not-merge/hold
-              - do-not-merge/work-in-progress
-              - needs-ok-to-test
-              - needs-rebase
-      policy:
-        protect: true
-        required_status_checks:
-          contexts:
-            entries:
-              - integration
+queries:
+  - labels:
+      entries:
+        - approved
+    missingLabels:
+      entries:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - needs-ok-to-test
+        - needs-rebase
+protection_policy:
+  protect: true
+  required_status_checks:
+    contexts:
+      entries:
+        - integration
 plugins:
   entries:
     - config-updater

--- a/pkg/pipelinescheduler/test_data/policy_with_parent/parent.yaml
+++ b/pkg/pipelinescheduler/test_data/policy_with_parent/parent.yaml
@@ -60,23 +60,25 @@ presubmits:
       context: integration
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
-      queries:
-        - labels:
-            entries:
-              - approved
-          missingLabels:
-            entries:
-              - do-not-merge
-              - do-not-merge/hold
-              - do-not-merge/work-in-progress
-              - needs-ok-to-test
-              - needs-rebase
-      policy:
-        protect: true
-        required_status_checks:
-          contexts:
-            entries:
-              - integration
+
+queries:
+  - labels:
+      entries:
+        - approved
+    missingLabels:
+      entries:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - needs-ok-to-test
+        - needs-rebase
+
+protection_policy:
+  protect: true
+  required_status_checks:
+    contexts:
+      entries:
+        - integration
 plugins:
   entries:
     - config-updater

--- a/pkg/pipelinescheduler/test_data/repo/repo.yaml
+++ b/pkg/pipelinescheduler/test_data/repo/repo.yaml
@@ -17,23 +17,23 @@ presubmits:
       name: integration
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
-      queries:
-        - labels:
-            entries:
-              - approved
-          missingLabels:
-            entries:
-              - do-not-merge
-              - do-not-merge/hold
-              - do-not-merge/work-in-progress
-              - needs-ok-to-test
-              - needs-rebase
-      policy:
-        protect: true
-        required_status_checks:
-          contexts:
-            entries:
-              - integration
+queries:
+  - labels:
+      entries:
+        - approved
+    missingLabels:
+      entries:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - needs-ok-to-test
+        - needs-rebase
+protection_policy:
+  protect: true
+  required_status_checks:
+    contexts:
+      entries:
+        - integration
 merger:
   policy:
     from-branch-protection: true

--- a/pkg/pipelinescheduler/test_data/with_parent/parent.yaml
+++ b/pkg/pipelinescheduler/test_data/with_parent/parent.yaml
@@ -32,23 +32,26 @@ presubmits:
       context: integration
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
-      queries:
-        - labels:
-            entries:
-              - approved
-          missingLabels:
-            entries:
-              - do-not-merge
-              - do-not-merge/hold
-              - do-not-merge/work-in-progress
-              - needs-ok-to-test
-              - needs-rebase
-      policy:
-        protect: true
-        required_status_checks:
-          contexts:
-            entries:
-              - integration
+
+queries:
+  - labels:
+      entries:
+        - approved
+    missingLabels:
+      entries:
+        - do-not-merge
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - needs-ok-to-test
+        - needs-rebase
+
+protection_policy:
+  protect: true
+  required_status_checks:
+    contexts:
+      entries:
+        - integration
+
 plugins:
   entries:
     - config-updater

--- a/pkg/pipelinescheduler/testhelpers/helpers.go
+++ b/pkg/pipelinescheduler/testhelpers/helpers.go
@@ -41,12 +41,10 @@ func CompleteScheduler() *schedulerapi.SchedulerSpec {
 			SyncPeriod:         pointerToRandomDuration(),
 		},
 		Presubmits: &schedulerapi.Presubmits{
-			Items: []*schedulerapi.Presubmit{
+			Items: []*job.Presubmit{
 				{
-					Presubmit: job.Presubmit{
-						Base: job.Base{
-							Name: "cheese",
-						},
+					Base: job.Base{
+						Name: "cheese",
 					},
 				},
 			},

--- a/pkg/schedulerapi/types.go
+++ b/pkg/schedulerapi/types.go
@@ -208,15 +208,10 @@ type Postsubmits struct {
 // configurations in the parent scheduler
 type Presubmits struct {
 	// Items are the Presubmit configurtations
-	Items []*Presubmit `json:"entries,omitempty" protobuf:"bytes,1,opt,name=entries"`
+	Items []*job.Presubmit `json:"entries,omitempty" protobuf:"bytes,1,opt,name=entries"`
 	// Replace the existing entries
 	Replace bool `json:"replace,omitempty" protobuf:"bytes,2,opt,name=replace"`
 }
-
-type Presubmit struct {
-	job.Presubmit
-}
-
 // Periodics is a list of jobs to be run periodically
 type Periodics struct {
 	// Items are the post submit configurations

--- a/pkg/schedulerapi/types.go
+++ b/pkg/schedulerapi/types.go
@@ -50,23 +50,37 @@ type SchedulerList struct {
 
 // SchedulerSpec defines the pipeline scheduler (e.g. Prow) configuration
 type SchedulerSpec struct {
-	ScehdulerAgent  *SchedulerAgent                    `json:"schedulerAgent,omitempty" protobuf:"bytes,1,opt,name=schedulerAgent"`
-	Policy          *GlobalProtectionPolicy            `json:"policy,omitempty" protobuf:"bytes,2,opt,name=policy"`
-	Presubmits      *Presubmits                        `json:"presubmits,omitempty" protobuf:"bytes,3,opt,name=presubmits"`
-	Postsubmits     *Postsubmits                       `json:"postsubmits,omitempty" protobuf:"bytes,4,opt,name=postsubmits"`
-	Trigger         *Trigger                           `json:"trigger,omitempty" protobuf:"bytes,5,opt,name=trigger"`
-	Approve         *Approve                           `json:"approve,omitempty" protobuf:"bytes,6,opt,name=approve"`
-	LGTM            *Lgtm                              `json:"lgtm,omitempty" protobuf:"bytes,7,opt,name=lgtm"`
-	ExternalPlugins *ReplaceableSliceOfExternalPlugins `json:"external_plugins,omitempty" protobuf:"bytes,8,opt,name=external_plugins"`
+	ScehdulerAgent *SchedulerAgent         `json:"schedulerAgent,omitempty" protobuf:"bytes,1,opt,name=schedulerAgent"`
+	Policy         *GlobalProtectionPolicy `json:"policy,omitempty" protobuf:"bytes,2,opt,name=policy"`
+	Presubmits     *Presubmits             `json:"presubmits,omitempty" protobuf:"bytes,3,opt,name=presubmits"`
+	Postsubmits    *Postsubmits            `json:"postsubmits,omitempty" protobuf:"bytes,4,opt,name=postsubmits"`
 
-	Merger *Merger `json:"merger,omitempty" protobuf:"bytes,9,opt,name=merger"`
+	// Queries add keeper queries
+	Queries []*Query `json:"queries,omitempty" protobuf:"bytes,5,opt,name=query"`
+	// MergeMethod Override the default method of merge. Valid options are squash, rebase, and merge.
+	MergeMethod *string `json:"merge_method,omitempty" protobuf:"bytes,6,opt,name=merge_method"`
+	// ProtectionPolicy the protection policy
+	ProtectionPolicy *ProtectionPolicies `json:"protection_policy,omitempty" protobuf:"bytes,7,opt,name=policy"`
+
+	// ContextOptions defines the merge options. If not set it will infer
+	// the required and optional contexts from the jobs configured and use the Git Provider
+	// combined status; otherwise it may apply the branch protection setting or let user
+	// define their own options in case branch protection is not used.
+	ContextOptions *RepoContextPolicy `json:"context_options,omitempty" protobuf:"bytes,8,opt,name=contextPolicy"`
+
+	Trigger         *Trigger                           `json:"trigger,omitempty" protobuf:"bytes,9,opt,name=trigger"`
+	Approve         *Approve                           `json:"approve,omitempty" protobuf:"bytes,10,opt,name=approve"`
+	LGTM            *Lgtm                              `json:"lgtm,omitempty" protobuf:"bytes,11,opt,name=lgtm"`
+	ExternalPlugins *ReplaceableSliceOfExternalPlugins `json:"external_plugins,omitempty" protobuf:"bytes,12,opt,name=external_plugins"`
+
+	Merger *Merger `json:"merger,omitempty" protobuf:"bytes,13,opt,name=merger"`
 
 	// Plugins is a list of plugin names enabled for a repo
-	Plugins       *ReplaceableSliceOfStrings `json:"plugins,omitempty" protobuf:"bytes,10,opt,name=plugins"`
-	ConfigUpdater *ConfigUpdater             `json:"config_updater,omitempty" protobuf:"bytes,11,opt,name=config_updater"`
-	Welcome       []*Welcome                 `json:"welcome,omitempty" protobuf:"bytes,12,opt,name=welcome"`
-	Periodics     *Periodics                 `json:"periodics,omitempty" protobuf:"bytes,13,opt,name=periodics"`
-	Attachments   []*Attachment              `json:"attachments,omitempty" protobuf:"bytes,13,opt,name=attachments"`
+	Plugins       *ReplaceableSliceOfStrings `json:"plugins,omitempty" protobuf:"bytes,14,opt,name=plugins"`
+	ConfigUpdater *ConfigUpdater             `json:"config_updater,omitempty" protobuf:"bytes,15,opt,name=config_updater"`
+	Welcome       []*Welcome                 `json:"welcome,omitempty" protobuf:"bytes,16,opt,name=welcome"`
+	Periodics     *Periodics                 `json:"periodics,omitempty" protobuf:"bytes,17,opt,name=periodics"`
+	Attachments   []*Attachment              `json:"attachments,omitempty" protobuf:"bytes,18,opt,name=attachments"`
 }
 
 // ConfigMapSpec contains configuration options for the configMap being updated
@@ -201,18 +215,6 @@ type Presubmits struct {
 
 type Presubmit struct {
 	job.Presubmit
-
-	// Override the default method of merge. Valid options are squash, rebase, and merge.
-	MergeType *string `json:"merge_method,omitempty" protobuf:"bytes,7,opt,name=merge_method"`
-
-	Queries []*Query `json:"queries,omitempty" protobuf:"bytes,8,opt,name=query"`
-
-	Policy *ProtectionPolicies `json:"policy,omitempty" protobuf:"bytes,9,opt,name=policy"`
-	// ContextOptions defines the merge options. If not set it will infer
-	// the required and optional contexts from the jobs configured and use the Git Provider
-	// combined status; otherwise it may apply the branch protection setting or let user
-	// define their own options in case branch protection is not used.
-	ContextPolicy *RepoContextPolicy `json:"context_options,omitempty" protobuf:"bytes,10,opt,name=contextPolicy"`
 }
 
 // Periodics is a list of jobs to be run periodically


### PR DESCRIPTION
so that we can keep presubmits purely in-repo and the rest can be centralised