### PR TITLE
fix: only run helmfile resolve if we have a helmfile

### DIFF
--- a/pkg/cmd/helmfile/resolve/resolve.go
+++ b/pkg/cmd/helmfile/resolve/resolve.go
@@ -338,6 +338,19 @@ func (o *Options) Run() error {
 	return nil
 }
 
+// HasHelmfile returns true if there is a helmfile
+func (o *Options) HasHelmfile() (bool, error) {
+	if o.Helmfile == "" {
+		o.Helmfile = filepath.Join(o.Dir, "helmfile.yaml")
+	}
+
+	exists, err := files.FileExists(o.Helmfile)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to check for file %s", o.Helmfile)
+	}
+	return exists, nil
+}
+
 func valuesContains(values []interface{}, value string) bool {
 	for _, v := range values {
 		if v == value {

--- a/pkg/cmd/upgrade/upgrade.go
+++ b/pkg/cmd/upgrade/upgrade.go
@@ -43,8 +43,15 @@ func (o *Options) Run() error {
 		return errors.Wrapf(err, "failed to update source using kpt")
 	}
 
-	log.Logger().Infof("\nnow checking the chart versions in %s\n\n", termcolor.ColorInfo("helmfile.yaml"))
+	exists, err := o.HelmfileResolve.HasHelmfile()
+	if err != nil {
+		return errors.Wrapf(err, "failed to check for helmfile")
+	}
+	if !exists {
+		return nil
+	}
 
+	log.Logger().Infof("\nnow checking the chart versions in %s\n\n", termcolor.ColorInfo("helmfile.yaml"))
 	o.HelmfileResolve.UpdateMode = true
 	err = o.HelmfileResolve.Run()
 	if err != nil {


### PR DESCRIPTION
so we can use `jx gitops upgrade` on any git repository - e.g. a quickstart