### PR TITLE
chore: use the release name to resove values files, which defaults to the chart name if release name is not set, which keeps existing behaviour.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2264,6 +2264,7 @@ google.golang.org/api v0.30.0/go.mod h1:QGmEvQ87FHZNiUVJkT14jQNYJ4ZJjdRF23ZXz513
 google.golang.org/api v0.31.0 h1:1w5Sz/puhxFo9lTtip2n47k7toB/U2nCqOKNHd3Yrbo=
 google.golang.org/api v0.31.0/go.mod h1:CL+9IBCa2WWU6gRuBWaKqGWLFFwbEUXkfeMkHLQWYWo=
 google.golang.org/api v0.32.0 h1:Le77IccnTqEa8ryp9wIpX5W3zYm7Gf9LhOp9PHcwFts=
+google.golang.org/api v0.33.0 h1:+gL0XvACeMIvpwLZ5rQZzLn5cwOsgg8dIcfJ2SYfBVw=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/pkg/cmd/helmfile/resolve/resolve.go
+++ b/pkg/cmd/helmfile/resolve/resolve.go
@@ -276,13 +276,13 @@ func (o *Options) Run() error {
 		// lets try resolve any values files in the version stream
 		found := false
 		for _, valueFileName := range valueFileNames {
-			versionStreamValuesFile := filepath.Join(versionsDir, "charts", prefix, chartName, valueFileName)
+			versionStreamValuesFile := filepath.Join(versionsDir, "charts", prefix, release.Name, valueFileName)
 			exists, err := files.FileExists(versionStreamValuesFile)
 			if err != nil {
 				return errors.Wrapf(err, "failed to check if version stream values file exists %s", versionStreamValuesFile)
 			}
 			if exists {
-				path := filepath.Join("versionStream", "charts", prefix, chartName, valueFileName)
+				path := filepath.Join("versionStream", "charts", prefix, release.Name, valueFileName)
 				if !valuesContains(release.Values, path) {
 					release.Values = append(release.Values, path)
 				}


### PR DESCRIPTION
this means we can install the same chart into different namespaces but configured with different helm values from a version stream

this is what keeps existing behaviour https://github.com/jenkins-x/jx-gitops/blob/1605cc7b845c0469f491768f219c63bf1a8da573/pkg/cmd/helmfile/resolve/resolve.go#L190-L192