### PR TITLE
fix: release pipeline branch name with '/' issue

### DIFF
--- a/pkg/cmd/variables/variables.go
+++ b/pkg/cmd/variables/variables.go
@@ -399,7 +399,7 @@ func (o *Options) FindBuildNumber(buildID string) (string, error) {
 	selectors := []string{
 		"owner=" + naming.ToValidName(owner) +
 			",repository=" + naming.ToValidName(repository) +
-			",branch=" + naming.ToValidName(branch),
+			",branch=" + branch,
 		"lighthouse.jenkins-x.io/refs.org=" + naming.ToValidName(owner) +
 			",lighthouse.jenkins-x.io/refs.repo=" + naming.ToValidName(repository) +
 			",lighthouse.jenkins-x.io/branch=" + branch,


### PR DESCRIPTION
Fixes the issue on release pipeline pod(on evaluation of `BuildNumber`) whenever release is made on branch name with `/` special character and `jx gitops variables` is a part of release pipeline STEP(with latest tekton catalog version, `in-repo` scheduler) like shown below.
```
        - args:
          - gitops
          - variables
          command:
          - jx
          image: gcr.io/jenkinsxio/jx-cli:latest
          name: jx-variables
          resources: {}
```
Error logs for the same issue for a release pipeline pod is shown below -:
`error: failed to validate: failed to find build number: failed to find BuildNumber: failed to find PipelineActivity resources in namespace jx with selector lighthouse.jenkins-x.io/refs.org=org,lighthouse.jenkins-x.io/refs.repo=service,lighthouse.jenkins-x.io/branch=hello/test-jenkins-x: unable to parse requirement: invalid label value: "team/test-jenkins-x": at key: "lighthouse.jenkins-x.io/branch": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')`