### PR TITLE
fix: allow tekton-secret mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,11 +11,11 @@ require (
 	github.com/jenkins-x/gen-crd-api-reference-docs v0.1.6 // indirect
 	github.com/jenkins-x/go-scm v1.5.188
 	github.com/jenkins-x/jx-api/v3 v3.0.1
-	github.com/jenkins-x/jx-helpers/v3 v3.0.9
+	github.com/jenkins-x/jx-helpers/v3 v3.0.11
 	github.com/jenkins-x/jx-kube-client/v3 v3.0.1
 	github.com/jenkins-x/jx-logging/v3 v3.0.2
 	github.com/jenkins-x/jx-secret v0.0.172 // indirect
-	github.com/jenkins-x/lighthouse v0.0.855
+	github.com/jenkins-x/lighthouse v0.0.857
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
 	github.com/roboll/helmfile v0.125.7

--- a/go.sum
+++ b/go.sum
@@ -1123,6 +1123,8 @@ github.com/jenkins-x/jx-helpers/v3 v3.0.8 h1:apVEJ+4yIyfR+XncHSjld0jtorfXyw+LLIQ
 github.com/jenkins-x/jx-helpers/v3 v3.0.8/go.mod h1:YulZCWgM+W49nkW7juaOwIEOyXkmwfaMdsC6/W5b+H8=
 github.com/jenkins-x/jx-helpers/v3 v3.0.9 h1:OxWU7u2l4rK4RlZ2fVyX3+ewusdcE0D5LQ6Ex9vp8ZM=
 github.com/jenkins-x/jx-helpers/v3 v3.0.9/go.mod h1:YulZCWgM+W49nkW7juaOwIEOyXkmwfaMdsC6/W5b+H8=
+github.com/jenkins-x/jx-helpers/v3 v3.0.11 h1:ZGynAE0AaVNR66gCoA3VMmo7WCBawv03bHzMrcNKa+Y=
+github.com/jenkins-x/jx-helpers/v3 v3.0.11/go.mod h1:YulZCWgM+W49nkW7juaOwIEOyXkmwfaMdsC6/W5b+H8=
 github.com/jenkins-x/jx-kube-client v0.0.8 h1:XK/TP2qnhHPb/vhaGHmvVilWGDtARIZ1DOEHp/6/h0Y=
 github.com/jenkins-x/jx-kube-client v0.0.8/go.mod h1:XvNZQAAF95wzQzSfCpehXwb5FI6WCg+5GiwVA2S4SPA=
 github.com/jenkins-x/jx-kube-client/v3 v3.0.0 h1:42Io8YswcXhIulUEMniSU21y9LscNrxPmsZ5/uZa+So=


### PR DESCRIPTION
which loads the git credential from the tekton-git secret in the current namespace