### PR TITLE
feat: Added in helmfile compatible conditional values for use in condition parameter of helmfile

### DIFF
--- a/pkg/jxtmpl/reqvalues/requirements_values.go
+++ b/pkg/jxtmpl/reqvalues/requirements_values.go
@@ -14,16 +14,26 @@ const (
 	RequirementsValuesFileName = "jx-values.yaml"
 )
 
+type HelmfileConditional struct {
+	Enabled bool `json:"enabled"`
+}
+
 // RequirementsValues contains the logical installation requirements in the `jx-requirements.yml` file as helm values
 type RequirementsValues struct {
 	// RequirementsConfig contains the logical installation requirements
-	RequirementsConfig *config.RequirementsConfig `json:"jxRequirements,omitempty"`
+	RequirementsConfig          *config.RequirementsConfig `json:"jxRequirements,omitempty"`
+	IngressExternalDNSCondition *HelmfileConditional       `json:"jxRequirementsIngressExternalDNS,omitempty"`
+	IngressTLSCondition         *HelmfileConditional       `json:"jxRequirementsIngressTLS,omitempty"`
+	VaultCondition              *HelmfileConditional       `json:"jxRequirementsVault,omitempty"`
 }
 
 // SaveRequirementsValuesFile saves the requirements yaml file for use with helmfile / helm 3
 func SaveRequirementsValuesFile(c *config.RequirementsConfig, fileName string) error {
 	y := &RequirementsValues{
-		RequirementsConfig: c,
+		RequirementsConfig:          c,
+		IngressExternalDNSCondition: &HelmfileConditional{Enabled: c.Ingress.ExternalDNS},
+		IngressTLSCondition:         &HelmfileConditional{Enabled: c.Ingress.TLS.Enabled},
+		VaultCondition:              &HelmfileConditional{Enabled: c.SecretStorage == config.SecretStorageTypeVault},
 	}
 	err := yamls.SaveFile(y, fileName)
 	if err != nil {


### PR DESCRIPTION
In order to use `condition` syntax in helmfile (https://github.com/roboll/helmfile/blame/88884b68dcbb0a5b01676e18bb53444cffa3c89b/README.md#L127) we need to output values in no more than two part notation due to the following logic in helmfile https://github.com/roboll/helmfile/blob/88884b68dcbb0a5b01676e18bb53444cffa3c89b/pkg/state/state.go#L1821

So we need to flatten our requirements hierarchies for anything we want to conditionally install via our helmfiles. Two obvious candidates that spring to mind are external-dns and cert-manager both of which we probably want to drive from our requirements file.