### PR TITLE
fix: handle different case in kpt error messages

### DIFF
--- a/pkg/cmd/kpt/update/update.go
+++ b/pkg/cmd/kpt/update/update.go
@@ -165,8 +165,8 @@ func (o *Options) Run() error {
 		log.Logger().Infof(text)
 		if err != nil {
 			lines := strings.Split(strings.TrimSpace(text), "\n")
-			errText := lines[len(lines)-1]
-			if errText == "Error: no updates" {
+			errText := strings.ToLower(lines[len(lines)-1])
+			if errText == "error: no updates" {
 				return nil
 			}
 			return errors.Wrapf(err, "failed to run kpt command")


### PR DESCRIPTION
avoid failing when kpt reports no updates which isn't really an error