### PR TITLE
fix: add escape command

### DIFF
--- a/pkg/cmd/helm/escape/espape.go
+++ b/pkg/cmd/helm/escape/espape.go
@@ -1,0 +1,127 @@
+package escape
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jenkins-x/jx-gitops/pkg/rootcmd"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/cobras/helper"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/cobras/templates"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/files"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/termcolor"
+	"github.com/jenkins-x/jx-logging/v3/pkg/log"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cmdLong = templates.LongDesc(`
+		Escapes any {{ or }} characters in the YAML files so they can be included in a helm chart
+`)
+
+	cmdExample = templates.Examples(`
+		# escapes any yaml files so they can be included in a helm chart 
+		%s helm escape --dir myyaml
+	`)
+)
+
+// Options the options for the command
+type Options struct {
+	Dir string
+}
+
+// NewCmdEscape creates a command object for the command
+func NewCmdEscape() (*cobra.Command, *Options) {
+	o := &Options{}
+
+	cmd := &cobra.Command{
+		Use:     "escape",
+		Short:   "Escapes any {{ or }} characters in the YAML files so they can be included in a helm chart",
+		Long:    cmdLong,
+		Example: fmt.Sprintf(cmdExample, rootcmd.BinaryName),
+		Run: func(cmd *cobra.Command, args []string) {
+			err := o.Run()
+			helper.CheckErr(err)
+		},
+	}
+	cmd.Flags().StringVarP(&o.Dir, "dir", "d", ".", "the directory to recursively look for the *.yaml or *.yml files")
+	return cmd, o
+}
+
+// Run implements the command
+func (o *Options) Run() error {
+	return EncodeYAMLFiles(o.Dir)
+}
+
+// EncodeYAMLFiles splits any files with multiple resources into separate files
+func EncodeYAMLFiles(dir string) error {
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if info == nil || info.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".yaml") {
+			return nil
+		}
+		data, err := ioutil.ReadFile(path)
+		if err != nil {
+			return errors.Wrapf(err, "failed to load file %s", path)
+		}
+
+		modified := false
+		lines := strings.Split(string(data), "\n")
+
+		buf := strings.Builder{}
+		for _, line := range lines {
+			encoded := escape(line)
+			if encoded != line {
+				modified = true
+			}
+			buf.WriteString(encoded)
+			buf.WriteString("\n")
+		}
+
+		if !modified {
+			return nil
+		}
+
+		err = ioutil.WriteFile(path, []byte(buf.String()), files.DefaultFileWritePermissions)
+		if err != nil {
+			return errors.Wrapf(err, "failed to save %s", path)
+		}
+
+		log.Logger().Infof("encoded file %s", termcolor.ColorInfo(path))
+		return nil
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to split YAML files in dir %s", dir)
+	}
+	return nil
+}
+
+const (
+	openDelim  = `{{ "{{" }}`
+	closeDelim = `{{ "}}" }}`
+)
+
+func escape(line string) string {
+	i1 := strings.Index(line, "{{")
+	i2 := strings.Index(line, "}}")
+
+	if i1 < 0 && i2 < 0 {
+		return line
+	}
+	i := i2
+	delim := closeDelim
+	if i2 < 0 || (i1 < i2 && i1 >= 0) {
+		i = i1
+		delim = openDelim
+	}
+	prefix := line[0:i] + delim
+	if i+2 >= len(line) {
+		return prefix
+	}
+	return prefix + escape(line[i+2:])
+}

--- a/pkg/cmd/helm/escape/espape_test.go
+++ b/pkg/cmd/helm/escape/espape_test.go
@@ -1,0 +1,35 @@
+package escape_test
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/jenkins-x/jx-gitops/pkg/cmd/helm/escape"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/files"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/testhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEscapeYAML(t *testing.T) {
+	srcDir := filepath.Join("test_data", "src")
+	require.DirExists(t, srcDir)
+
+	tmpDir, err := ioutil.TempDir("", "")
+	require.NoError(t, err, "could not create temp dir")
+
+	err = files.CopyDirOverwrite(srcDir, tmpDir)
+	require.NoError(t, err, "failed to copy %s to %s", srcDir, tmpDir)
+
+	_, o := escape.NewCmdEscape()
+	o.Dir = tmpDir
+
+	err = o.Run()
+	require.NoError(t, err, "failed to run in dir %s", srcDir, tmpDir)
+
+	t.Logf("escape files in dir %s\n", tmpDir)
+
+	srcFile := filepath.Join(tmpDir, "config-observability-cm.yaml")
+	expectedFile := filepath.Join("test_data", "expected", "config-observability-cm.yaml")
+	testhelpers.AssertEqualFileText(t, expectedFile, srcFile)
+}

--- a/pkg/cmd/helm/escape/test_data/expected/config-observability-cm.yaml
+++ b/pkg/cmd/helm/escape/test_data/expected/config-observability-cm.yaml
@@ -1,0 +1,119 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.19.0"
+  annotations:
+    knative.dev/example-checksum: "97c1d10b"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # logging.enable-var-log-collection defaults to false.
+    # The fluentd daemon set will be set up to collect /var/log if
+    # this flag is true.
+    logging.enable-var-log-collection: "false"
+
+    # logging.revision-url-template provides a template to use for producing the
+    # logging URL that is injected into the status of each Revision.
+    logging.revision-url-template: "http://logging.example.com/?revisionUID=${REVISION_UID}"
+
+    # If non-empty, this enables queue proxy writing user request logs to stdout, excluding probe
+    # requests.
+    # NB: after 0.18 release logging.enable-request-log must be explicitly set to true
+    # in order for request logging to be enabled.
+    #
+    # The value determines the shape of the request logs and it must be a valid go text/template.
+    # It is important to keep this as a single line. Multiple lines are parsed as separate entities
+    # by most collection agents and will split the request logs into multiple records.
+    #
+    # The following fields and functions are available to the template:
+    #
+    # Request: An http.Request (see https://golang.org/pkg/net/http/#Request)
+    # representing an HTTP request received by the server.
+    #
+    # Response:
+    # struct {
+    #   Code    int       // HTTP status code (see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
+    #   Size    int       // An int representing the size of the response.
+    #   Latency float64   // A float64 representing the latency of the response in seconds.
+    # }
+    #
+    # Revision:
+    # struct {
+    #   Name          string  // Knative revision name
+    #   Namespace     string  // Knative revision namespace
+    #   Service       string  // Knative service name
+    #   Configuration string  // Knative configuration name
+    #   PodName       string  // Name of the pod hosting the revision
+    #   PodIP         string  // IP of the pod hosting the revision
+    # }
+    #
+    logging.request-log-template: '{"httpRequest": {"requestMethod": "{{ "{{" }}.Request.Method{{ "}}" }}", "requestUrl": "{{ "{{" }}js .Request.RequestURI{{ "}}" }}", "requestSize": "{{ "{{" }}.Request.ContentLength{{ "}}" }}", "status": {{ "{{" }}.Response.Code{{ "}}" }}, "responseSize": "{{ "{{" }}.Response.Size{{ "}}" }}", "userAgent": "{{ "{{" }}js .Request.UserAgent{{ "}}" }}", "remoteIp": "{{ "{{" }}js .Request.RemoteAddr{{ "}}" }}", "serverIp": "{{ "{{" }}.Revision.PodIP{{ "}}" }}", "referer": "{{ "{{" }}js .Request.Referer{{ "}}" }}", "latency": "{{ "{{" }}.Response.Latency{{ "}}" }}s", "protocol": "{{ "{{" }}.Request.Proto{{ "}}" }}"}, "traceId": "{{ "{{" }}index .Request.Header "X-B3-Traceid"{{ "}}" }}"}'
+
+    # If true, the request logging will be enabled.
+    # NB: up to and including Knative version 0.18 if logging.request-log-template is non-empty, this value
+    # will be ignored.
+    logging.enable-request-log: "false"
+
+    # If true, this enables queue proxy writing request logs for probe requests to stdout.
+    # It uses the same template for user requests, i.e. logging.request-log-template.
+    logging.enable-probe-request-log: "false"
+
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or stackdriver.
+    # Note: Using stackdriver will incur additional charges
+    metrics.backend-destination: prometheus
+
+    # metrics.request-metrics-backend-destination specifies the request metrics
+    # destination. It enables queue proxy to send request metrics.
+    # Currently supported values: prometheus (the default), stackdriver.
+    metrics.request-metrics-backend-destination: prometheus
+
+    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
+    # field is optional. When running on GCE, application default credentials will be
+    # used if this field is not provided.
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
+    # Stackdriver using "global" resource type and custom metric type if the
+    # metrics are not supported by "knative_revision" resource type. Setting this
+    # flag to "true" could cause extra Stackdriver charge.
+    # If metrics.backend-destination is not Stackdriver, this is ignored.
+    metrics.allow-stackdriver-custom-metrics: "false"
+
+    # profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
+    # the pods via an HTTP server in the format expected by the pprof visualization tool. When
+    # enabled, the Knative Serving pods expose the profiling data on an alternate HTTP port 8008.
+    # The HTTP context root for profiling is then /debug/pprof/.
+    profiling.enable: "false"
+

--- a/pkg/cmd/helm/escape/test_data/src/config-observability-cm.yaml
+++ b/pkg/cmd/helm/escape/test_data/src/config-observability-cm.yaml
@@ -1,0 +1,118 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-observability
+  namespace: knative-serving
+  labels:
+    serving.knative.dev/release: "v0.19.0"
+  annotations:
+    knative.dev/example-checksum: "97c1d10b"
+data:
+  _example: |
+    ################################
+    #                              #
+    #    EXAMPLE CONFIGURATION     #
+    #                              #
+    ################################
+
+    # This block is not actually functional configuration,
+    # but serves to illustrate the available configuration
+    # options and document them in a way that is accessible
+    # to users that `kubectl edit` this config map.
+    #
+    # These sample configuration options may be copied out of
+    # this example block and unindented to be in the data block
+    # to actually change the configuration.
+
+    # logging.enable-var-log-collection defaults to false.
+    # The fluentd daemon set will be set up to collect /var/log if
+    # this flag is true.
+    logging.enable-var-log-collection: "false"
+
+    # logging.revision-url-template provides a template to use for producing the
+    # logging URL that is injected into the status of each Revision.
+    logging.revision-url-template: "http://logging.example.com/?revisionUID=${REVISION_UID}"
+
+    # If non-empty, this enables queue proxy writing user request logs to stdout, excluding probe
+    # requests.
+    # NB: after 0.18 release logging.enable-request-log must be explicitly set to true
+    # in order for request logging to be enabled.
+    #
+    # The value determines the shape of the request logs and it must be a valid go text/template.
+    # It is important to keep this as a single line. Multiple lines are parsed as separate entities
+    # by most collection agents and will split the request logs into multiple records.
+    #
+    # The following fields and functions are available to the template:
+    #
+    # Request: An http.Request (see https://golang.org/pkg/net/http/#Request)
+    # representing an HTTP request received by the server.
+    #
+    # Response:
+    # struct {
+    #   Code    int       // HTTP status code (see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)
+    #   Size    int       // An int representing the size of the response.
+    #   Latency float64   // A float64 representing the latency of the response in seconds.
+    # }
+    #
+    # Revision:
+    # struct {
+    #   Name          string  // Knative revision name
+    #   Namespace     string  // Knative revision namespace
+    #   Service       string  // Knative service name
+    #   Configuration string  // Knative configuration name
+    #   PodName       string  // Name of the pod hosting the revision
+    #   PodIP         string  // IP of the pod hosting the revision
+    # }
+    #
+    logging.request-log-template: '{"httpRequest": {"requestMethod": "{{.Request.Method}}", "requestUrl": "{{js .Request.RequestURI}}", "requestSize": "{{.Request.ContentLength}}", "status": {{.Response.Code}}, "responseSize": "{{.Response.Size}}", "userAgent": "{{js .Request.UserAgent}}", "remoteIp": "{{js .Request.RemoteAddr}}", "serverIp": "{{.Revision.PodIP}}", "referer": "{{js .Request.Referer}}", "latency": "{{.Response.Latency}}s", "protocol": "{{.Request.Proto}}"}, "traceId": "{{index .Request.Header "X-B3-Traceid"}}"}'
+
+    # If true, the request logging will be enabled.
+    # NB: up to and including Knative version 0.18 if logging.request-log-template is non-empty, this value
+    # will be ignored.
+    logging.enable-request-log: "false"
+
+    # If true, this enables queue proxy writing request logs for probe requests to stdout.
+    # It uses the same template for user requests, i.e. logging.request-log-template.
+    logging.enable-probe-request-log: "false"
+
+    # metrics.backend-destination field specifies the system metrics destination.
+    # It supports either prometheus (the default) or stackdriver.
+    # Note: Using stackdriver will incur additional charges
+    metrics.backend-destination: prometheus
+
+    # metrics.request-metrics-backend-destination specifies the request metrics
+    # destination. It enables queue proxy to send request metrics.
+    # Currently supported values: prometheus (the default), stackdriver.
+    metrics.request-metrics-backend-destination: prometheus
+
+    # metrics.stackdriver-project-id field specifies the stackdriver project ID. This
+    # field is optional. When running on GCE, application default credentials will be
+    # used if this field is not provided.
+    metrics.stackdriver-project-id: "<your stackdriver project id>"
+
+    # metrics.allow-stackdriver-custom-metrics indicates whether it is allowed to send metrics to
+    # Stackdriver using "global" resource type and custom metric type if the
+    # metrics are not supported by "knative_revision" resource type. Setting this
+    # flag to "true" could cause extra Stackdriver charge.
+    # If metrics.backend-destination is not Stackdriver, this is ignored.
+    metrics.allow-stackdriver-custom-metrics: "false"
+
+    # profiling.enable indicates whether it is allowed to retrieve runtime profiling data from
+    # the pods via an HTTP server in the format expected by the pprof visualization tool. When
+    # enabled, the Knative Serving pods expose the profiling data on an alternate HTTP port 8008.
+    # The HTTP context root for profiling is then /debug/pprof/.
+    profiling.enable: "false"

--- a/pkg/cmd/helm/helm.go
+++ b/pkg/cmd/helm/helm.go
@@ -2,6 +2,7 @@ package helm
 
 import (
 	"github.com/jenkins-x/jx-gitops/pkg/cmd/helm/build"
+	"github.com/jenkins-x/jx-gitops/pkg/cmd/helm/escape"
 	"github.com/jenkins-x/jx-gitops/pkg/cmd/helm/release"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/cobras"
 	"github.com/jenkins-x/jx-logging/v3/pkg/log"
@@ -23,6 +24,7 @@ func NewCmdHelm() *cobra.Command {
 	command.AddCommand(cobras.SplitCommand(NewCmdHelmTemplate()))
 	command.AddCommand(cobras.SplitCommand(NewCmdHelmStream()))
 	command.AddCommand(cobras.SplitCommand(build.NewCmdHelmBuild()))
+	command.AddCommand(cobras.SplitCommand(escape.NewCmdEscape()))
 	command.AddCommand(cobras.SplitCommand(release.NewCmdHelmRelease()))
 	return command
 }


### PR DESCRIPTION
so its easy to take any YAML which includes `{{` or `}}` (typically in sample `ConfigMap` data) and convert them so they can be packaged as helm charts