### PR TITLE
fix: support separate ingress domain per namespace

### DIFF
--- a/pkg/cmd/helmfile/add/add.go
+++ b/pkg/cmd/helmfile/add/add.go
@@ -5,7 +5,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/jenkins-x/jx-gitops/pkg/jxtmpl/reqvalues"
 	"github.com/jenkins-x/jx-gitops/pkg/versionstreamer"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/gitclient"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/gitclient/cli"
@@ -121,13 +120,6 @@ func (o *Options) Validate() error {
 	o.prefixes, err = o.Options.Resolver.GetRepositoryPrefixes()
 	if err != nil {
 		return errors.Wrapf(err, "failed to load repository prefixes at %s", o.VersionStreamDir)
-	}
-
-	jxReqValuesFileName := filepath.Join(o.Dir, reqvalues.RequirementsValuesFileName)
-	o.Results.RequirementsValuesFileName = reqvalues.RequirementsValuesFileName
-	err = reqvalues.SaveRequirementsValuesFile(o.Options.Requirements, jxReqValuesFileName)
-	if err != nil {
-		return errors.Wrapf(err, "failed to save tempo file for jx requirements values file %s", jxReqValuesFileName)
 	}
 	return nil
 }

--- a/pkg/cmd/helmfile/resolve/resolve.go
+++ b/pkg/cmd/helmfile/resolve/resolve.go
@@ -7,12 +7,12 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/jenkins-x/jx-gitops/pkg/jxtmpl/reqvalues"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/termcolor"
 
 	jxcore "github.com/jenkins-x/jx-api/v4/pkg/apis/core/v4beta1"
 	"github.com/jenkins-x/jx-gitops/pkg/cmd/helmfile/structure"
 	"github.com/jenkins-x/jx-gitops/pkg/helmhelpers"
-	"github.com/jenkins-x/jx-gitops/pkg/jxtmpl/reqvalues"
 	"github.com/jenkins-x/jx-gitops/pkg/plugins"
 	"github.com/jenkins-x/jx-gitops/pkg/versionstreamer"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/cmdrunner"
@@ -152,12 +152,6 @@ func (o *Options) Validate() error {
 		return errors.Wrapf(err, "failed to load repository prefixes at %s", o.VersionStreamDir)
 	}
 
-	jxReqValuesFileName := filepath.Join(o.Dir, reqvalues.RequirementsValuesFileName)
-	o.Results.RequirementsValuesFileName = reqvalues.RequirementsValuesFileName
-	err = reqvalues.SaveRequirementsValuesFile(o.Options.Requirements, jxReqValuesFileName)
-	if err != nil {
-		return errors.Wrapf(err, "failed to save tempo file for jx requirements values file %s", jxReqValuesFileName)
-	}
 	if o.CommandRunner == nil {
 		o.CommandRunner = cmdrunner.QuietCommandRunner
 	}
@@ -211,7 +205,8 @@ func (o *Options) Run() error {
 
 func (o *Options) processHelmfile(helmfile Helmfile) (int, error) {
 	helmState := state.HelmState{}
-	err := yaml2s.LoadFile(helmfile.filepath, &helmState)
+	path := helmfile.filepath
+	err := yaml2s.LoadFile(path, &helmState)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to load helmfile %s", helmfile)
 	}
@@ -222,12 +217,29 @@ func (o *Options) processHelmfile(helmfile Helmfile) (int, error) {
 			return 0, errors.Wrapf(err, "failed to perform custom upgrades")
 		}
 	}
+
+	if helmfile.relativePathToRoot != "" {
+		helmfileDir := filepath.Dir(path)
+		jxReqValuesFileName := filepath.Join(helmfileDir, reqvalues.RequirementsValuesFileName)
+		o.Results.RequirementsValuesFileName = reqvalues.RequirementsValuesFileName
+		requirements := *o.Options.Requirements
+		if err != nil {
+			return 0, errors.Wrapf(err, "failed to save tempo file for jx requirements values file %s", jxReqValuesFileName)
+		}
+		ns := helmState.OverrideNamespace
+		if ns == "" {
+			_, ns = filepath.Split(helmfileDir)
+		}
+		requirements.Ingress.NamespaceSubDomain = strings.ReplaceAll(requirements.Ingress.NamespaceSubDomain, "jx", ns)
+		err = reqvalues.SaveRequirementsValuesFile(&requirements, o.Dir, jxReqValuesFileName)
+	}
+
 	increment, err := o.resolveHelmfile(&helmState, helmfile)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to resolve helmfile %s", helmfile)
 	}
 
-	err = yaml2s.SaveFile(helmState, helmfile.filepath)
+	err = yaml2s.SaveFile(helmState, path)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to save file %s", helmfile)
 	}
@@ -264,7 +276,6 @@ func (o *Options) upgradeHelmfileStructure(dir string) (int, error) {
 }
 
 func (o *Options) resolveHelmfile(helmState *state.HelmState, helmfile Helmfile) (int, error) {
-
 	var err error
 	var ignoreRepositories []string
 	if !helmhelpers.IsInCluster() || o.TestOutOfCluster {
@@ -279,16 +290,27 @@ func (o *Options) resolveHelmfile(helmState *state.HelmState, helmfile Helmfile)
 		return 0, errors.Wrapf(err, "failed to add helm repositories")
 	}
 
-	/*
-		TODO lazily create environments file?
-		requirementsValuesFiles := o.Results.RequirementsValuesFileName
-		if requirementsValuesFiles != "" {
-			if stringhelpers.StringArrayIndex(helmState.Values, requirementsValuesFiles) < 0 {
-				helmState.Values = append(helmState.Values, requirementsValuesFiles)
+	if helmfile.relativePathToRoot != "" {
+		// ensure we have added the jx-values.yaml file in the envirionment
+		if helmState.Environments == nil {
+			helmState.Environments = map[string]state.EnvironmentSpec{}
+		}
+		envSpec := helmState.Environments["default"]
+		foundValuesFile := false
+		for _, v := range envSpec.Values {
+			s, ok := v.(string)
+			if ok && s == reqvalues.RequirementsValuesFileName {
+				foundValuesFile = true
+				break
 			}
 		}
+		if !foundValuesFile {
+			envValue := helmState.Environments["default"]
+			envValue.Values = append(envValue.Values, reqvalues.RequirementsValuesFileName)
+			helmState.Environments["default"] = envValue
+		}
+	}
 
-	*/
 	count := 0
 	for i, release := range helmState.Releases {
 		// TODO
@@ -436,6 +458,19 @@ func (o *Options) resolveHelmfile(helmState *state.HelmState, helmfile Helmfile)
 			}
 		}
 
+		if helmfile.relativePathToRoot != "" {
+			foundValuesFile := false
+			for _, v := range release.Values {
+				s, ok := v.(string)
+				if ok && s == reqvalues.RequirementsValuesFileName {
+					foundValuesFile = true
+					break
+				}
+			}
+			if !foundValuesFile {
+				release.Values = append(release.Values, reqvalues.RequirementsValuesFileName)
+			}
+		}
 		helmState.Releases[i] = release
 	}
 

--- a/pkg/cmd/helmfile/resolve/test_data/bucketrepo-svc/expected-jx-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/test_data/bucketrepo-svc/expected-jx-helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: jx
 repositories:
 - name: dev
@@ -9,10 +13,14 @@ releases:
 - chart: dev/dummy
   version: 1.2.3
   name: dummy
+  values:
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 - chart: jx3/jx-build-controller
   name: jx-build-controller
+  values:
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 templates: {}

--- a/pkg/cmd/helmfile/resolve/test_data/bucketrepo-svc/expected-tekton-pipelines-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/test_data/bucketrepo-svc/expected-tekton-pipelines-helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: tekton-pipelines
 repositories:
 - name: cdf
@@ -9,6 +13,7 @@ releases:
   name: tekton-pipeline
   values:
   - ../../versionStream/charts/cdf/tekton-pipeline/values.yaml.gotmpl
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 templates: {}

--- a/pkg/cmd/helmfile/resolve/test_data/input/expected-foo-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/test_data/input/expected-foo-helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: foo
 repositories:
 - name: bitnami
@@ -9,6 +13,7 @@ releases:
   name: external-dns
   values:
   - ../../values/external-dns/values.yaml
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 templates: {}

--- a/pkg/cmd/helmfile/resolve/test_data/input/expected-jx-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/test_data/input/expected-jx-helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: jx
 repositories:
 - name: stable
@@ -15,19 +19,26 @@ releases:
   name: chartmuseum
   values:
   - ../../versionStream/charts/stable/chartmuseum/values.yaml.gotmpl
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 - chart: jenkins-x/jxboot-helmfile-resources
   version: 0.0.255
   name: jxboot-helmfile-resources
+  values:
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 - chart: doesnotexist/bucketrepo
   name: bucketrepo
+  values:
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 - chart: jx3/jx-build-controller
   name: jx-build-controller
+  values:
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 templates: {}

--- a/pkg/cmd/helmfile/resolve/test_data/input/expected-secret-infra-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/test_data/input/expected-secret-infra-helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: secret-infra
 repositories:
 - name: external-secrets
@@ -9,6 +13,7 @@ releases:
   name: kubernetes-external-secrets
   values:
   - ../../values/kubernetes-external-secrets/values.yaml.gotmpl
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 templates: {}

--- a/pkg/cmd/helmfile/resolve/test_data/input/expected-tekton-pipelines-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/test_data/input/expected-tekton-pipelines-helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: tekton-pipelines
 repositories:
 - name: cdf
@@ -9,6 +13,7 @@ releases:
   name: tekton-pipeline
   values:
   - ../../versionStream/charts/cdf/tekton-pipeline/values.yaml.gotmpl
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 templates: {}

--- a/pkg/cmd/helmfile/resolve/test_data/local-secrets/expected-jx-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/test_data/local-secrets/expected-jx-helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: jx
 repositories:
 - name: jenkins-x
@@ -9,6 +13,8 @@ releases:
 - chart: jenkins-x/jxboot-helmfile-resources
   version: 0.0.255
   name: jxboot-helmfile-resources
+  values:
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 - chart: jx3/jenkins-x-crds
@@ -16,15 +22,20 @@ releases:
   name: jenkins-x-crds
   values:
   - ../../versionStream/charts/jx3/jenkins-x-crds/values.yaml.gotmpl
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 - chart: jx3/local-external-secrets
   version: 0.0.3
   name: local-external-secrets
+  values:
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 - chart: jx3/jx-build-controller
   name: jx-build-controller
+  values:
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 templates: {}

--- a/pkg/cmd/helmfile/resolve/test_data/local-secrets/expected-secret-infra-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/test_data/local-secrets/expected-secret-infra-helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: secret-infra
 repositories:
 - name: jx3
@@ -6,10 +10,14 @@ repositories:
 releases:
 - chart: jx3/vault-instance
   name: vault-instance
+  values:
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 - chart: jx3/pusher-wave
   name: pusher-wave
+  values:
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 templates: {}

--- a/pkg/cmd/helmfile/resolve/test_data/local-secrets/expected-tekton-pipelines-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/test_data/local-secrets/expected-tekton-pipelines-helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: tekton-pipelines
 repositories:
 - name: cdf
@@ -9,6 +13,7 @@ releases:
   name: tekton-pipeline
   values:
   - ../../versionStream/charts/cdf/tekton-pipeline/values.yaml.gotmpl
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 templates: {}

--- a/pkg/cmd/helmfile/resolve/test_data/no-versionstream/expected-external-secrets-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/test_data/no-versionstream/expected-external-secrets-helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: external-secrets
 repositories:
 - name: external-secrets
@@ -9,6 +13,7 @@ releases:
   name: kubernetes-external-secrets
   values:
   - ../../values/kubernetes-external-secrets/values.yaml.gotmpl
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 templates: {}

--- a/pkg/cmd/helmfile/resolve/test_data/no-versionstream/expected-foo-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/test_data/no-versionstream/expected-foo-helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: foo
 repositories:
 - name: bitnami
@@ -9,6 +13,7 @@ releases:
   name: external-dns
   values:
   - ../../values/external-dns/values.yaml
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 templates: {}

--- a/pkg/cmd/helmfile/resolve/test_data/no-versionstream/expected-jx-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/test_data/no-versionstream/expected-jx-helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: jx
 repositories:
 - name: jenkins-x
@@ -11,14 +15,20 @@ releases:
 - chart: jenkins-x/jxboot-helmfile-resources
   version: 0.0.255
   name: jxboot-helmfile-resources
+  values:
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 - chart: doesnotexist/bucketrepo
   name: bucketrepo
+  values:
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 - chart: jx3/jx-build-controller
   name: jx-build-controller
+  values:
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 templates: {}

--- a/pkg/cmd/helmfile/resolve/test_data/no-versionstream/expected-tekton-pipelines-helmfile.yaml
+++ b/pkg/cmd/helmfile/resolve/test_data/no-versionstream/expected-tekton-pipelines-helmfile.yaml
@@ -1,4 +1,8 @@
 filepath: ""
+environments:
+  default:
+    values:
+    - jx-values.yaml
 namespace: tekton-pipelines
 repositories:
 - name: cdf
@@ -9,6 +13,7 @@ releases:
   name: tekton-pipeline
   values:
   - ../../versionStream/charts/cdf/tekton-pipeline/values.yaml.gotmpl
+  - jx-values.yaml
   forceNamespace: ""
   skipDeps: null
 templates: {}

--- a/pkg/helmhelpers/helpers_test.go
+++ b/pkg/helmhelpers/helpers_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStepHelmfileResolve(t *testing.T) {
+func TestFindClusterLocalRepositoryURLs(t *testing.T) {
 	repos := []state.RepositorySpec{
 		{
 			Name: "jx",

--- a/pkg/jxtmpl/reqvalues/requirements_values.go
+++ b/pkg/jxtmpl/reqvalues/requirements_values.go
@@ -1,7 +1,11 @@
 package reqvalues
 
 import (
+	"path/filepath"
+
 	jxcore "github.com/jenkins-x/jx-api/v4/pkg/apis/core/v4beta1"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/files"
+	"github.com/jenkins-x/jx-helpers/v3/pkg/maps"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/termcolor"
 	"github.com/jenkins-x/jx-helpers/v3/pkg/yamls"
 	"github.com/jenkins-x/jx-logging/v3/pkg/log"
@@ -25,25 +29,62 @@ type RequirementsValues struct {
 	IngressExternalDNSCondition *HelmfileConditional       `json:"jxRequirementsIngressExternalDNS,omitempty"`
 	IngressTLSCondition         *HelmfileConditional       `json:"jxRequirementsIngressTLS,omitempty"`
 	VaultCondition              *HelmfileConditional       `json:"jxRequirementsVault,omitempty"`
+	JX                          map[string]interface{}     `json:"jx,omitempty"`
 }
 
 // SaveRequirementsValuesFile saves the requirements yaml file for use with helmfile / helm 3
-func SaveRequirementsValuesFile(c *jxcore.RequirementsConfig, fileName string) error {
+func SaveRequirementsValuesFile(c *jxcore.RequirementsConfig, dir, fileName string) error {
 	// lets initialise an empty struct to handle backwards compatibility
 	if c.Ingress.TLS == nil {
 		c.Ingress.TLS = &jxcore.TLSConfig{}
 	}
+	jxGlobals, err := loadJXGlobals(dir)
+	if err != nil {
+		return errors.Wrapf(err, "failed to load global helm values files")
+	}
+
 	y := &RequirementsValues{
 		RequirementsConfig:          c,
 		IngressExternalDNSCondition: &HelmfileConditional{Enabled: c.Ingress.ExternalDNS},
 		IngressTLSCondition:         &HelmfileConditional{Enabled: c.Ingress.TLS.Enabled},
 		VaultCondition:              &HelmfileConditional{Enabled: c.SecretStorage == jxcore.SecretStorageTypeVault},
+		JX:                          jxGlobals,
 	}
 
-	err := yamls.SaveFile(y, fileName)
+	err = yamls.SaveFile(y, fileName)
 	if err != nil {
 		return errors.Wrapf(err, "failed to save file %s", fileName)
 	}
 	log.Logger().Debugf("generated helm YAML file from jx requirements at %s", termcolor.ColorInfo(fileName))
 	return nil
+}
+
+func loadJXGlobals(dir string) (map[string]interface{}, error) {
+	answer := map[string]interface{}{}
+
+	fileNames := []string{
+		filepath.Join(dir, "versionStream", "src", "fake-secrets.yaml.gotmpl"),
+		filepath.Join(dir, "imagePullSecrets.yaml"),
+		filepath.Join(dir, "jx-global-values.yaml"),
+	}
+	for _, f := range fileNames {
+		m := map[string]interface{}{}
+		exists, err := files.FileExists(f)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to check if file exists %s", f)
+		}
+		if exists {
+			err := yamls.LoadFile(f, &m)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to load file %s", f)
+			}
+			maps.CombineMapTrees(answer, m)
+		}
+	}
+	v := answer["jx"]
+	m, ok := v.(map[string]interface{})
+	if ok {
+		return m, nil
+	}
+	return nil, nil
 }


### PR DESCRIPTION
by using a namespace specific jx-values.yaml file for each namespace helmfile which contains the combination of requirements, global values and any fake secrets

ideally there would be a nice way to do this in helmfile without repeating the file name in the enivironment and in each chart; but until there is we have to do it this way