### PR TITLE
fix: gitea webhook update creating duplicate hooks

### DIFF
--- a/pkg/cmd/webhook/verify/verify.go
+++ b/pkg/cmd/webhook/verify/verify.go
@@ -311,7 +311,7 @@ func (o *Options) matchesWebhookURL(webHookArgs *scm.Hook, webhookURL string) bo
 	if "" != o.PreviousHookUrl {
 		return o.PreviousHookUrl == webHookArgs.Target
 	}
-	if o.ScmClientFactory.GitKind == "gitlab" {
+	if o.ScmClientFactory.GitKind == "gitlab" || o.ScmClientFactory.GitKind == "gitea" {
 		return strings.HasPrefix(webHookArgs.Target, webhookURL)
 	}
 	if o.ExactHookMatch {


### PR DESCRIPTION
The gitea webhook contains a secret parameter so use prefix match

fixes https://github.com/jenkins-x/jx-gitops/issues/476