### PR TITLE
fix: helm lint should be called after dependency build

### DIFF
--- a/pkg/cmd/helm/release/release.go
+++ b/pkg/cmd/helm/release/release.go
@@ -205,21 +205,21 @@ func (o *Options) Run() error {
 		c = &cmdrunner.Command{
 			Dir:  chartDir,
 			Name: o.HelmBinary,
-			Args: []string{"lint"},
-		}
-		_, err = o.CommandRunner(c)
-		if err != nil {
-			return errors.Wrapf(err, "failed to lint")
-		}
-
-		c = &cmdrunner.Command{
-			Dir:  chartDir,
-			Name: o.HelmBinary,
 			Args: []string{"dependency", "build", "."},
 		}
 		_, err = o.CommandRunner(c)
 		if err != nil {
 			return errors.Wrapf(err, "failed to build dependencies")
+		}
+
+		c = &cmdrunner.Command{
+			Dir:  chartDir,
+			Name: o.HelmBinary,
+			Args: []string{"lint"},
+		}
+		_, err = o.CommandRunner(c)
+		if err != nil {
+			return errors.Wrapf(err, "failed to lint")
 		}
 
 		c = &cmdrunner.Command{


### PR DESCRIPTION
lint fails if a dependency is missing so...
Funny thing, this can't be circumvented by changing the pipeline to call `helm dependency build` before of `jx gitops helm release` because of https://github.com/helm/helm/issues/9164