### PR TITLE
chore: add custom upgrade for external secrets chart

### DIFF
--- a/pkg/cmd/helmfile/resolve/resolve.go
+++ b/pkg/cmd/helmfile/resolve/resolve.go
@@ -642,6 +642,10 @@ func (o *Options) CustomUpgrades(helmstate *state.HelmState) error {
 			repo.URL = "https://charts.helm.sh/stable"
 		case "https://godaddy.github.io/kubernetes-external-secrets":
 			repo.URL = "https://external-secrets.github.io/kubernetes-external-secrets"
+		case "https://external-secrets.github.io/kubernetes-external-secrets":
+			repo.URL = "https://storage.googleapis.com/jenkinsxio/charts"
+		case "https://chrismellard.github.io/kubernetes-external-secrets":
+			repo.URL = "https://storage.googleapis.com/jenkinsxio/charts"
 		}
 	}
 


### PR DESCRIPTION
this is while we wait for PR https://github.com/external-secrets/kubernetes-external-secrets/pull/615 to merge