### PR TITLE
chore: expose prometheus metrics on lighthouse

### DIFF
--- a/pkg/pipelinescheduler/config_builder.go
+++ b/pkg/pipelinescheduler/config_builder.go
@@ -209,6 +209,7 @@ func buildExternalPlugin(answer *plugins.ExternalPlugin, plugin *schedulerapi.Ex
 }
 
 func buildProwConfig(prowConfig *config.ProwConfig, scheduler *schedulerapi.SchedulerSpec, org string, repo string) error {
+	prowConfig.PushGateway.ServeMetrics = true
 	if scheduler.Policy != nil {
 		err := buildGlobalBranchProtection(&prowConfig.BranchProtection, scheduler.Policy)
 		if err != nil {

--- a/pkg/pipelinescheduler/test_data/merger_with_mergemethod/config.yaml
+++ b/pkg/pipelinescheduler/test_data/merger_with_mergemethod/config.yaml
@@ -42,7 +42,8 @@ presubmits:
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
 #prowjob_namespace: jx
-#push_gateway: {}
+push_gateway:
+  serve_metrics: true
 #sinker: {}
 tide:
   merge_method:

--- a/pkg/pipelinescheduler/test_data/merger_with_parent/config.yaml
+++ b/pkg/pipelinescheduler/test_data/merger_with_parent/config.yaml
@@ -42,7 +42,8 @@ presubmits:
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
 #prowjob_namespace: jx
-#push_gateway: {}
+push_gateway:
+  serve_metrics: true
 #sinker: {}
 tide:
   target_url: http://targeturl

--- a/pkg/pipelinescheduler/test_data/multiple_contexts/config.yaml
+++ b/pkg/pipelinescheduler/test_data/multiple_contexts/config.yaml
@@ -63,7 +63,8 @@ presubmits:
       rerun_command: /test context3
       trigger: (?m)^/test( all| context3),?(\s+|$)
 #prowjob_namespace: jx
-#push_gateway: {}
+push_gateway:
+  serve_metrics: true
 #sinker: {}
 tide:
   context_options:

--- a/pkg/pipelinescheduler/test_data/no_postsubmits_with_parent/config.yaml
+++ b/pkg/pipelinescheduler/test_data/no_postsubmits_with_parent/config.yaml
@@ -31,7 +31,8 @@ presubmits:
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
 #prowjob_namespace: jx
-#push_gateway: {}
+push_gateway:
+  serve_metrics: true
 #sinker: {}
 tide:
   context_options:

--- a/pkg/pipelinescheduler/test_data/only_with_parent/config.yaml
+++ b/pkg/pipelinescheduler/test_data/only_with_parent/config.yaml
@@ -42,7 +42,8 @@ presubmits:
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
 #prowjob_namespace: jx
-#push_gateway: {}
+push_gateway:
+  serve_metrics: true
 #sinker: {}
 tide:
   context_options:

--- a/pkg/pipelinescheduler/test_data/policy_with_parent/config.yaml
+++ b/pkg/pipelinescheduler/test_data/policy_with_parent/config.yaml
@@ -71,7 +71,8 @@ presubmits:
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
 #prowjob_namespace: jx
-#push_gateway: {}
+push_gateway:
+  serve_metrics: true
 #sinker: {}
 tide:
   context_options:

--- a/pkg/pipelinescheduler/test_data/repo/config.yaml
+++ b/pkg/pipelinescheduler/test_data/repo/config.yaml
@@ -42,7 +42,8 @@ presubmits:
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
 #prowjob_namespace: jx
-#push_gateway: {}
+push_gateway:
+  serve_metrics: true
 #sinker: {}
 tide:
   context_options:

--- a/pkg/pipelinescheduler/test_data/with_parent/config.yaml
+++ b/pkg/pipelinescheduler/test_data/with_parent/config.yaml
@@ -42,7 +42,8 @@ presubmits:
       rerun_command: /test this
       trigger: (?m)^/test( all| this),?(\s+|$)
 #prowjob_namespace: jx
-#push_gateway: {}
+push_gateway:
+  serve_metrics: true
 #sinker: {}
 tide:
   context_options:


### PR DESCRIPTION
lighthouse uses its config to know if it should expose an internal http handler with prometheus metrics (on /metrics)
let's enable it by default - lighthouse is already taking care of using an internal http server for it, so it has no security impact (on the webhook server which might be exposed to everybody)

note that it's not enough to enable automatic scraping of the metrics by prometheus: for that, we need to add a specific label on the lighthouse pods